### PR TITLE
chore: update backend API endpoint

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,23 +6,23 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: 'http://193.70.34.25:20096/api/:path*',
+        destination: 'http://147.135.252.68:20085/api/:path*',
       },
       {
         source: '/laporan-images/:path*',
-        destination: 'http://193.70.34.25:20096/laporan-images/:path*',
+        destination: 'http://147.135.252.68:20085/laporan-images/:path*',
       },
       {
         source: '/task-images/:path*',
-        destination: 'http://193.70.34.25:20096/task-images/:path*',
+        destination: 'http://147.135.252.68:20085/task-images/:path*',
       },
     ];
   },
   // Allow hot-reload / _next asset requests from these additional origins while running `next dev`.
   // See https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins
   allowedDevOrigins: [
-    '193.70.34.25:20096',        // your external IP & port
-    '193.70.34.25:20096',          // whatever host is proxying requests (example shown in warning)
+    '147.135.252.68:20085',        // your external IP & port
+    '147.135.252.68:20085',          // whatever host is proxying requests (example shown in warning)
     '*.127.0.0.1.nip.io',          // handy wildcard for tunnelling URLs (optional)
   ],
   // Skip ESLint checks during `next build` so build won\'t fail on lint errors.

--- a/src/components/FetchProxy.tsx
+++ b/src/components/FetchProxy.tsx
@@ -4,13 +4,13 @@ import { useEffect } from "react";
 
 /**
  * Patch the global fetch on the client so that any request that still points
- * to the hard-coded backend base URL (http://193.70.34.25:20096) is converted
+ * to the hard-coded backend base URL (http://147.135.252.68:20085) is converted
  * to a same-origin relative URL. This prevents mixed-content errors when the
  * site is served over HTTPS (e.g. on Vercel).
  */
 export default function FetchProxy() {
   useEffect(() => {
-    const BACKEND = "http://193.70.34.25:20096";
+    const BACKEND = "http://147.135.252.68:20085";
 
     // Ensure we only patch once and in browsers.
     if (typeof window === "undefined" || (window as any).__FETCH_PROXY_PATCHED__) {


### PR DESCRIPTION
## Summary
- point API rewrites and dev origins to new backend server
- update client fetch proxy to use new backend URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abe1f2feb883238cfbf47ef48673ba